### PR TITLE
Move to alpine-based docker-make docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,8 @@
-FROM ubuntu:19.10
-
+ARG DOCKER_MAKE_VERSION=alpine
+FROM metalstack/docker-make:${DOCKER_MAKE_VERSION}
 LABEL repository="https://github.com/metal-stack/action-docker-make"
 LABEL maintainer="metal-stack authors <info@metal-stack.io>"
-
-ARG DOCKER_MAKE_VERSION=v0.3.3
-
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get --yes install --no-install-recommends \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg2 \
-    git \
-    lz4 \
-    software-properties-common \
- && curl -fsSLo /usr/local/bin/docker-make https://github.com/fi-ts/docker-make/releases/download/${DOCKER_MAKE_VERSION}/docker-make-linux-amd64 \
- && chmod +x /usr/local/bin/docker-make \
- && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
- && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu eoan stable" \
- && apt-get update \
- && apt-get --yes install --no-install-recommends docker-ce
-
 COPY LICENSE README.md /
 COPY entrypoint.sh /
-
+RUN mv /docker-make /usr/local/bin/docker-make
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-echo "" 
+echo ""
 cd "${GITHUB_WORKSPACE}"
 
 export DOCKER_MAKE_REGISTRY_LOGIN_USER="${INPUT_USERNAME}"
 export DOCKER_MAKE_REGISTRY_LOGIN_PASSWORD="${INPUT_PASSWORD}"
 
-docker-make --log-level=DEBUG ${INPUT_ARGS}
+docker-make ${INPUT_ARGS}


### PR DESCRIPTION
This makes the docker-make action only viable for building docker-images. Complex before or after actions are probably not recommended for the action. For more complex use cases docker-make should be run from the runner directly and not through this docker container.